### PR TITLE
[LD-237] Make sure to set system enviroment variable in crontab.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,11 @@
 
 Refer to `docker-compose.yml` for example.
 
-- `AWS_ACCESS_KEY`: AWS Access Key to be used when uploading backups to S3 bucket
-- `AWS_SECRET_KEY`: AWS Secret Key to be used when uploading backups to S3 bucket
-- `MYSQL_ROOT_PASSWORD`: Root password for MySQL
-- `S3_BUCKET`: Location of the S3 backup. For eg: `s3://a-sample-bucket/some/database/backuppath/`
+- `AWS_ACCESS_KEY`: AWS Access Key to be used when uploading backups to S3 bucket.
+- `AWS_SECRET_KEY`: AWS Secret Key to be used when uploading backups to S3 bucket.
+- `MYSQL_ROOT_PASSWORD`: Root password for MySQL.
+- `S3_BUCKET`: Location of the S3 backup. For eg: `s3://a-sample-bucket/some/database/backuppath/`.
+- `BACKUP_DISABLED`: Set this to skip the backup. 
 
 ### Optional Docker System Environment
 

--- a/scripts/configure-cron
+++ b/scripts/configure-cron
@@ -8,9 +8,15 @@ if [ ! -x $BACKUP_DISABLED ]; then
 fi
 
 
-echo SHELL=/bin/bash > $CRONTAB_FILE
-echo PATH=$PATH >> $CRONTAB_FILE
-cat /etc/crontab.schedule >> $CRONTAB_FILE
-echo  >> $CRONTAB_FILE
+
+cat <<EOF > $CRONTAB_FILE
+SHELL=/bin/bash
+PATH=$PATH
+MYSQL_ROOT_PASSWORD=$MYSQL_ROOT_PASSWORD
+AWS_ACCESS_KEY=$AWS_ACCESS_KEY
+AWS_SECRET_KEY=$AWS_SECRET_KEY
+EOF
+
+cat /etc/crontab.schedule  >> $CRONTAB_FILE
 
 exec /usr/sbin/cron -f


### PR DESCRIPTION
`innobackupex-runner` fails to  run due to invalid MySQL config.